### PR TITLE
Fixed compilation issues encountered when using Windows + /W4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(smolog STATIC smolog.hpp smolog.cpp)
 if(SMOLOG_DISABLE_MACROS)
 	target_compile_definitions(smolog PRIVATE -DSMOLOG_DISABLE_MACROS)
 endif(SMOLOG_DISABLE_MACROS)
+target_include_directories(smolog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(smolog PRIVATE _CRT_SECURE_NO_WARNINGS)
 add_executable(smolog_examples examples.cpp)
 
 target_link_libraries(smolog_examples smolog)

--- a/smolog.cpp
+++ b/smolog.cpp
@@ -234,7 +234,7 @@ namespace smolog {
 
 	file_sink::file_sink(const char * filename, bool truncate) : _internal(std::make_unique<_file_state>()){
 		const char * open_flags = truncate ? "w" : "a";
-		int err = fopen_s(&_internal->fd, filename, open_flags);
+		fopen_s(&_internal->fd, filename, open_flags);
 	}
 
 	void file_sink::write(const message & msg) {


### PR DESCRIPTION
Not sure if straight-up defining _CRT_SECURE_NO_WARNINGS on all platforms is the way to go, but it works.